### PR TITLE
Fix `evolve` and values in the tests for operators

### DIFF
--- a/src/density_matrix.rs
+++ b/src/density_matrix.rs
@@ -311,7 +311,10 @@ impl DensityMatrix {
                 // Extract bits at target positions and compose bitmask
                 let mut b_i = 0;
                 let mut b_j = 0;
-                let bitmask: usize = target_bitshifts.iter().enumerate().map(|(index, t)| {
+                /* `target_bitshifts` is ordered from the most to the least significant bits
+                   to extract to `b_i` and `b_j`, therefore the iteration is reversed for
+                   `index` to match the weight of the extracted bits. */
+                let bitmask: usize = target_bitshifts.iter().rev().enumerate().map(|(index, t)| {
                     b_i |= ((i >> t) & 1) << index;
                     b_j |= ((j >> t) & 1) << index;
                     1 << t

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 mod density_matrix;
 mod operators;
-mod tensor;
+//mod tensor;
 mod tools;
 
 fn main() {}

--- a/tests/tests_operators.rs
+++ b/tests/tests_operators.rs
@@ -41,25 +41,25 @@ mod tests_operators {
     fn test_operator_cx() {
         let cx_gate = Operator::two_qubits(TwoQubitsOp::CX);
         assert_eq!(cx_gate.data[0], Complex::new(1., 0.));
-        assert_eq!(cx_gate.data[1], Complex::new(1., 0.));
-        assert_eq!(cx_gate.data[2], Complex::new(1., 0.));
-        assert_eq!(cx_gate.data[3], Complex::new(1., 0.));
+        assert_eq!(cx_gate.data[5], Complex::new(1., 0.));
+        assert_eq!(cx_gate.data[11], Complex::new(1., 0.));
+        assert_eq!(cx_gate.data[14], Complex::new(1., 0.));
     }
     #[test]
     fn test_operator_cz() {
         let cz_gate = Operator::two_qubits(TwoQubitsOp::CZ);
         assert_eq!(cz_gate.data[0], Complex::new(1., 0.));
-        assert_eq!(cz_gate.data[1], Complex::new(1., 0.));
-        assert_eq!(cz_gate.data[2], Complex::new(1., 0.));
-        assert_eq!(cz_gate.data[3], Complex::new(-1., 0.));
+        assert_eq!(cz_gate.data[5], Complex::new(1., 0.));
+        assert_eq!(cz_gate.data[10], Complex::new(1., 0.));
+        assert_eq!(cz_gate.data[15], Complex::new(-1., 0.));
     }
     #[test]
     fn test_operator_swap() {
         let swap_gate = Operator::two_qubits(TwoQubitsOp::SWAP);
         assert_eq!(swap_gate.data[0], Complex::new(1., 0.));
-        assert_eq!(swap_gate.data[1], Complex::new(1., 0.));
-        assert_eq!(swap_gate.data[2], Complex::new(1., 0.));
-        assert_eq!(swap_gate.data[3], Complex::new(1., 0.));
+        assert_eq!(swap_gate.data[6], Complex::new(1., 0.));
+        assert_eq!(swap_gate.data[9], Complex::new(1., 0.));
+        assert_eq!(swap_gate.data[15], Complex::new(1., 0.));
     }
     #[test]
     fn test_transconjugate_x() {


### PR DESCRIPTION
This PR fixes `evolve` and values in the tests for operators.

`target_bitshifts` is ordered from the most to the least significant bits to extract to `b_i` and `b_j`, therefore the iteration on `target_bitshifts` reversed to be in the increasing order of the weight of the extracted bits.

Reference to `tensor` module is removed from `main` since the module does not exist anymore.